### PR TITLE
Fix NULL ptr dereference on EC_POINT *point

### DIFF
--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -1156,7 +1156,7 @@ int i2o_ECPublicKey(const EC_KEY *a, unsigned char **out)
     size_t buf_len = 0;
     int new_buffer = 0;
 
-    if (a == NULL) {
+    if (a == NULL || a->pub_key == NULL) {
         ERR_raise(ERR_LIB_EC, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }

--- a/crypto/ec/ec_oct.c
+++ b/crypto/ec/ec_oct.c
@@ -74,6 +74,10 @@ size_t EC_POINT_point2oct(const EC_GROUP *group, const EC_POINT *point,
                           point_conversion_form_t form, unsigned char *buf,
                           size_t len, BN_CTX *ctx)
 {
+    if (point == NULL) {
+        ERR_raise(ERR_LIB_EC, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
     if (group->meth->point2oct == 0
         && !(group->meth->flags & EC_FLAGS_DEFAULT_OCT)) {
         ERR_raise(ERR_LIB_EC, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);


### PR DESCRIPTION
Use non-usual params of pkcs11 module will trigger a null ptr deref bug. Fix it for #25493

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
